### PR TITLE
feat: implement add free-text traits

### DIFF
--- a/cypress/integration/Start/AddTraits.feature
+++ b/cypress/integration/Start/AddTraits.feature
@@ -1,0 +1,13 @@
+@addTraits
+Feature: AddTraits
+
+  User can add traits 
+
+  Background:
+    Given I open the egenskaper-page
+
+  Scenario: User can add a trait
+    When I click Lägg till en ny egenskap
+    When I type "Accepterande" as a "trait"
+    When I press OK 
+    Then "Accepterande" should be added as a trait 

--- a/cypress/support/step_definitions/addTraits.js
+++ b/cypress/support/step_definitions/addTraits.js
@@ -1,0 +1,19 @@
+Given('I open the egenskaper-page', () => {
+  cy.visit('/skapa-cv/egenskaper')
+})
+
+When('I click Lägg till en ny egenskap', () => {
+  cy.get(`[data-testid="addTraitButton"`).click()
+})
+
+When('I type {string} as a {string}', (input, fieldName) => {
+  cy.get(`[name="${fieldName}"]`).type(input)
+})
+
+When('I press OK', () => {
+  cy.get('[data-testid="okButton"]').click()
+})
+
+Then('{string} should be added as a trait', trait => {
+  cy.get('[data-testid="tagList"]').should('contain', trait)
+})

--- a/src/components/ButtonToInput.tsx
+++ b/src/components/ButtonToInput.tsx
@@ -9,14 +9,15 @@ interface ButtonToInputProps {
   addButtonText?: string
   inputPlaceholder: string
   onSelect: (value: string) => void
+  onChange?: (value: string) => void
 }
 
-const InputWrapper = styled(Input)`
+export const InputWrapper = styled(Input)`
   display: flex;
   align-items: center;
 `
 
-const TagButton = styled(Tag)`
+export const TagButton = styled(Tag)`
   background-color: ${({ theme }) => theme.colors.white};
   color: ${({ theme }) => theme.colors.redOrange};
   font-weight: 600;
@@ -26,6 +27,7 @@ const ButtonToInput: React.FC<ButtonToInputProps> = ({
   addButtonText = 'OK',
   buttonText,
   inputPlaceholder,
+  onChange,
   onSelect,
 }) => {
   const [inputValue, setInputValue] = React.useState('')
@@ -35,10 +37,14 @@ const ButtonToInput: React.FC<ButtonToInputProps> = ({
   const handleSelect = () => {
     onSelect(inputValue)
     setAddCompetenceActive()
+    setInputValue('')
   }
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value)
+    if (typeof onChange === 'function') {
+      onChange(event.target.value)
+    }
   }
 
   React.useEffect(() => {
@@ -68,7 +74,7 @@ const ButtonToInput: React.FC<ButtonToInputProps> = ({
       </TagButton>
     </InputWrapper>
   ) : (
-    <Tag mb="medium" mt="small" onClick={setAddCompetenceActive}>
+    <Tag role="button" mb="medium" mt="small" onClick={setAddCompetenceActive}>
       {buttonText}
     </Tag>
   )

--- a/src/components/ButtonToInput.tsx
+++ b/src/components/ButtonToInput.tsx
@@ -74,7 +74,7 @@ const ButtonToInput: React.FC<ButtonToInputProps> = ({
       </TagButton>
     </InputWrapper>
   ) : (
-    <Tag role="button" mb="medium" mt="small" onClick={setAddCompetenceActive}>
+    <Tag mb="medium" mt="small" onClick={setAddCompetenceActive} role="button">
       {buttonText}
     </Tag>
   )

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,13 +1,37 @@
 import styled from '@emotion/styled'
-import { color, ColorProps, space, SpaceProps } from 'styled-system'
+import {
+  borders,
+  BordersProps,
+  borderRadius,
+  BorderRadiusProps,
+  color,
+  ColorProps,
+  space,
+  SpaceProps,
+} from 'styled-system'
 
-type ListProps = React.HTMLProps<HTMLUListElement> & ColorProps & SpaceProps
+type ListProps = React.HTMLProps<HTMLUListElement> &
+  BordersProps &
+  BorderRadiusProps &
+  ColorProps &
+  SpaceProps
 
-const List = styled.ul<ListProps>`
+export const List = styled.ul<ListProps>`
   list-style: none;
 
+  ${borders}
+  ${borderRadius}
   ${color}
   ${space}
+`
+
+const SearchList = styled(List)<{ isOpen: boolean }>`
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  box-shadow: ${({ theme }) => `0px 8px 16px 0px ${theme.colors.whiteLilac}`};
+  max-height: 224px;
+  overflow-x: hidden;
+  overflow-y: auto;
 `
 
 List.defaultProps = {
@@ -15,4 +39,10 @@ List.defaultProps = {
   p: 0,
 }
 
-export default List
+SearchList.defaultProps = {
+  borderTop: 0,
+  color: 'persianBlue',
+  p: 0,
+}
+
+export { List as default, SearchList }

--- a/src/components/TagList.tsx
+++ b/src/components/TagList.tsx
@@ -22,7 +22,12 @@ const TagList: React.FC<TagListProps<TagItemProps>> = ({
     activeItems.find(({ id }) => id === selectedId)
 
   return (
-    <Flex alignItems="center" flexWrap="wrap" justifyContent="center">
+    <Flex
+      alignItems="center"
+      data-testid="tagList"
+      flexWrap="wrap"
+      justifyContent="center"
+    >
       {[...activeItems, ...items].map(item => (
         <Tag
           key={item.id}

--- a/src/components/__tests__/__snapshots__/List.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/List.spec.tsx.snap
@@ -3,8 +3,8 @@
 exports[`components/List renders a List 1`] = `
 <div>
   <ul
-    class="css-1n9h91p"
+    class="css-1h90lzp"
     color="persianBlue"
   />
 </div>
-`
+`;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -75,7 +75,6 @@ export const storageHelper = {
     localStorage.setItem(payload.type, JSON.stringify(payload.data)),
 }
 
-
 export const highlightMarked = (inputValue: string, term: string) => {
   const reg = new RegExp(inputValue, 'i')
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -74,3 +74,12 @@ export const storageHelper = {
   set: (payload: StorageEntry) =>
     localStorage.setItem(payload.type, JSON.stringify(payload.data)),
 }
+
+
+export const highlightMarked = (inputValue: string, term: string) => {
+  const reg = new RegExp(inputValue, 'i')
+
+  return {
+    __html: term.replace(reg, `<strong>${inputValue}</strong>`),
+  }
+}

--- a/src/views/CreateProfile/AddTraits.tsx
+++ b/src/views/CreateProfile/AddTraits.tsx
@@ -156,12 +156,12 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
                     borderRadius={8}
                     data-testid="okButton"
                     ml={6}
-                    p="small"
-                    role="button"
                     onClick={() => {
                       handleChange(traitQuery)
                       setAddTraitActive()
                     }}
+                    p="small"
+                    role="button"
                   >
                     OK
                   </TagButton>
@@ -209,10 +209,10 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
         ) : (
           <Tag
             data-testid="addTraitButton"
-            role="button"
             mb="medium"
             mt="small"
             onClick={setAddTraitActive}
+            role="button"
           >
             + Lägg till en ny egenskap
           </Tag>

--- a/src/views/CreateProfile/AddTraits.tsx
+++ b/src/views/CreateProfile/AddTraits.tsx
@@ -1,23 +1,29 @@
 import { RouteComponentProps } from '@reach/router'
-import Grid from '../../components/Grid'
+import Flex from '../../components/Flex'
 import { v4 } from 'uuid'
 import { useMutation, useQuery } from 'react-apollo-hooks'
 import React, { useEffect, useState } from 'react'
-import { useDebounce } from '@iteam/hooks'
-import styled from '@emotion/styled'
+import { useDebounce, useToggle } from '@iteam/hooks'
+import Downshift from 'downshift'
+import { Global, css } from '@emotion/core'
+import Input from '../../components/Input'
+import { SearchList } from '../../components/List'
+import Tag from '../../components/Tag'
+import ListItem from '../../components/ListItem'
+import { InputWrapper, TagButton } from '../../components/ButtonToInput'
 import { H1 } from '../../components/Typography'
 import {
   OntologyTextParseResponse,
   Query,
   OntologyType,
+  OntologyConceptResponse,
 } from '../../generated/myskills.d'
 import gql from 'graphql-tag'
 import { GET_ONTOLOGY_CONCEPTS } from './ChooseProfession'
 import { GET_TRAITS_CLIENT } from '../../graphql/resolvers/mutations/addTrait'
+import { highlightMarked } from '../../utils/helpers'
 import TagList from '../../components/TagList'
 import RegistrationLayout from '../../components/Layout/RegistrationLayout'
-
-const AddTrait = styled.input``
 
 export const ADD_TRAIT = gql`
   mutation addTrait($trait: String!) {
@@ -38,32 +44,30 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
   const { data: { traits = [] } = { traits: [] as string[] } } = useQuery(
     GET_TRAITS_CLIENT
   )
-  const [query, setQuery] = useState('')
+
+  const [traitQuery, setTraitQuery] = useState('')
+  const [addTraitActive, setAddTraitActive] = useToggle(false)
 
   const { data: ontologyRelated } = useQuery<{
-    ontologyConcept: Query['ontologyConcept']
+    ontologyConcepts: Query['ontologyConcept'][]
   }>(GET_ONTOLOGY_CONCEPTS, {
     variables: {
-      filter: useDebounce(query, 500),
+      filter: useDebounce(traitQuery, 500),
       type: OntologyType.Trait,
     },
-    skip: !query,
+    skip: !traitQuery,
   })
+
+  const addTraitMutation = useMutation(ADD_TRAIT)
+  const removeTraitMutation = useMutation(REMOVE_TRAIT)
 
   const [suggestedTraits, setSuggestedTraits] = useState(
     navigationTraits.map(t => t.term)
   )
 
-  const addTraitMutation = useMutation(ADD_TRAIT)
-  const removeTraitMutation = useMutation(REMOVE_TRAIT)
-
-  const handleChange = (e: any) => {
-    if (e.keyCode && e.keyCode === 13) {
-      addTrait(query)
-      setQuery('')
-    } else {
-      setQuery(e.currentTarget.value)
-    }
+  const handleChange = (value: string) => {
+    addTrait(value)
+    setTraitQuery('')
   }
 
   const removeTrait = (trait: string) => {
@@ -100,20 +104,120 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
 
   return (
     <RegistrationLayout headerText="PERSON" nextPath="kontakt" step={5}>
-      <Grid alignItems="start" justifyContent="start">
+      <Flex
+        alignItems="center"
+        flexDirection="column"
+        justifyContent="flex-start"
+      >
         <H1 textAlign="center">Vilka är dina främsta egenskaper?</H1>
         <TagList
           activeItems={traits.map(trait => ({ id: v4(), term: trait }))}
           items={suggestedTraits.map(trait => ({ id: v4(), term: trait }))}
           onSelect={onTagClick}
         />
-        <AddTrait
-          onChange={handleChange}
-          onKeyUp={handleChange}
-          placeholder="Lägg till en annan egenskap"
-          value={query}
+        <Global
+          styles={css`
+            strong {
+              font-weight: 700;
+              text-transform: capitalize;
+            }
+          `}
         />
-      </Grid>
+        {addTraitActive ? (
+          <Downshift
+            itemToString={item => (item ? item.term : '')}
+            onChange={(item: OntologyConceptResponse) =>
+              setTraitQuery(item.term)
+            }
+          >
+            {({
+              getInputProps,
+              getItemProps,
+              getMenuProps,
+              isOpen,
+              inputValue,
+              highlightedIndex,
+            }) => (
+              <div>
+                <InputWrapper as="div" mt="small" p={0}>
+                  <Input
+                    alignSelf="stretch"
+                    border="none"
+                    {...getInputProps({
+                      name: 'trait',
+                      placeholder: 'Lägg till en egenskap',
+                      onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+                        setTraitQuery(event.target.value),
+                      value: traitQuery,
+                    })}
+                  />
+
+                  <TagButton
+                    borderRadius={8}
+                    data-testid="okButton"
+                    ml={6}
+                    p="small"
+                    role="button"
+                    onClick={() => {
+                      handleChange(traitQuery)
+                      setAddTraitActive()
+                    }}
+                  >
+                    OK
+                  </TagButton>
+                </InputWrapper>
+
+                {ontologyRelated && ontologyRelated.ontologyConcepts && (
+                  <SearchList isOpen={isOpen} {...getMenuProps()}>
+                    {isOpen
+                      ? ontologyRelated.ontologyConcepts
+                          .filter(
+                            (item: OntologyConceptResponse) =>
+                              !inputValue ||
+                              item.term
+                                .toLowerCase()
+                                .includes(inputValue.toLowerCase())
+                          )
+                          .map(
+                            (item: OntologyConceptResponse, index: number) => (
+                              <ListItem
+                                bg={
+                                  highlightedIndex === index
+                                    ? 'seashellPeach'
+                                    : 'white'
+                                }
+                                key={item.id}
+                                px="medium"
+                                {...getItemProps({
+                                  key: item.id,
+                                  index,
+                                  item,
+                                  dangerouslySetInnerHTML: highlightMarked(
+                                    inputValue,
+                                    item.term
+                                  ),
+                                })}
+                              />
+                            )
+                          )
+                      : null}
+                  </SearchList>
+                )}
+              </div>
+            )}
+          </Downshift>
+        ) : (
+          <Tag
+            data-testid="addTraitButton"
+            role="button"
+            mb="medium"
+            mt="small"
+            onClick={setAddTraitActive}
+          >
+            + Lägg till en ny egenskap
+          </Tag>
+        )}
+      </Flex>
     </RegistrationLayout>
   )
 }

--- a/src/views/CreateProfile/ChooseProfession.tsx
+++ b/src/views/CreateProfile/ChooseProfession.tsx
@@ -11,25 +11,16 @@ import Input from '../../components/Input'
 import IllustrationHeader from '../../components/IllustrationHeader'
 import suitcaseIllustration from '../../assets/illustrations/suitcase.svg'
 import ListItem from '../../components/ListItem'
-import List from '../../components/List'
+import { SearchList } from '../../components/List'
 import styled from '@emotion/styled'
 import { css, Global } from '@emotion/core'
 import ChosenOccupation from '../../components/ChosenOccupation'
 import Downshift from 'downshift'
+import { highlightMarked } from '../../utils/helpers'
 import RegistrationLayout from '../../components/Layout/RegistrationLayout'
 
 const SearchInput = styled(Input)`
   width: 100%;
-`
-
-const SearchList = styled(List)<{ isOpen: boolean }>`
-  border-top: none;
-  max-height: 224px;
-  overflow-x: hidden;
-  overflow-y: auto;
-  box-shadow: ${({ theme }) => `0px 8px 16px 0px ${theme.colors.whiteLilac}`};
-  border-bottom-right-radius: 8px;
-  border-bottom-left-radius: 8px;
 `
 
 export const GET_ONTOLOGY_CONCEPTS = gql`
@@ -73,13 +64,6 @@ export const IS_LOGGED_IN = gql`
     isLoggedIn @client(always: true)
   }
 `
-const highlightMarked = (inputValue: string, term: string) => {
-  const reg = new RegExp(inputValue, 'i')
-
-  return {
-    __html: term.replace(reg, `<strong>${inputValue}</strong>`),
-  }
-}
 
 const ChooseProfession: React.FC<RouteComponentProps> = () => {
   const [query, setQuery] = useState('')

--- a/src/views/CreateProfile/__tests__/AddTraits.spec.tsx
+++ b/src/views/CreateProfile/__tests__/AddTraits.spec.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react'
+import AddTraits, { ADD_TRAIT } from '../AddTraits'
+import { GET_ONTOLOGY_CONCEPTS } from '../ChooseProfession'
+import { render } from '../../../utils/test-utils'
+import { waitForElement, fireEvent } from 'react-testing-library'
+import { OntologyType } from '../../../generated/myskills.d'
+import { GET_TRAITS_CLIENT } from '../../../graphql/resolvers/mutations/addTrait'
+
+describe('views/AddTraits', () => {
+  let withResultsMock: any
+
+  beforeEach(() => {
+    withResultsMock = [
+      {
+        request: {
+          query: GET_TRAITS_CLIENT,
+        },
+        result: {
+          data: {
+            traits: ['Glad'],
+          },
+        },
+      },
+      {
+        request: {
+          query: GET_ONTOLOGY_CONCEPTS,
+          variables: {
+            filter: 'Accepterande',
+            type: OntologyType.Trait,
+          },
+        },
+        result: {
+          data: {
+            __typename: 'OntologyConceptsResult',
+            ontologyConcepts: [
+              {
+                id: 'daa4aa62-755d-56c9-a066-3ecaf4b77ee5',
+                term: 'Accepterande',
+                type: 'TRAIT',
+                __typename: 'OntologyConceptResponse',
+              },
+            ],
+          },
+        },
+      },
+      {
+        request: {
+          query: GET_TRAITS_CLIENT,
+        },
+        result: {
+          data: {
+            traits: ['Glad', 'Accepterande'],
+          },
+        },
+      },
+    ]
+  })
+
+  it('should render with traits query result', async () => {
+    const { getByPlaceholderText, getByText, getByTestId, container } = render(
+      <AddTraits />,
+      withResultsMock
+    )
+
+    const addTraitButton = await waitForElement(
+      () => getByTestId('addTraitButton'),
+      { container }
+    )
+
+    fireEvent.click(addTraitButton)
+
+    const addTraitInput = await waitForElement(() =>
+      getByPlaceholderText(/lägg till en egenskap/i)
+    )
+
+    fireEvent.change(addTraitInput, {
+      target: { value: 'Accepterande' },
+    })
+
+    fireEvent.click(getByText('OK'))
+
+    /* TODO: expect the newly added trait to actually be in the document */
+    expect(getByTestId('addTraitButton')).toBeInTheDocument()
+  })
+})

--- a/src/views/CreateProfile/__tests__/__snapshots__/MatchSkills.spec.tsx.snap
+++ b/src/views/CreateProfile/__tests__/__snapshots__/MatchSkills.spec.tsx.snap
@@ -70,6 +70,7 @@ exports[`views/MatchSkills renders loading state 1`] = `
         class="css-bhiavv"
         cursor="pointer"
         opacity="1"
+        role="button"
       >
         + Lägg till en kompetens
       </span>


### PR DESCRIPTION
**Ticket:** [#146](https://trello.com/c/1XAkCeCc/146-add-correct-styling-for-autocomplete-traits)
**Intent:**

Implement adding traits according to design

**How to test (optional):**

### All of the following commands should pass.

- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run cypress`

### Browser testing

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE11
- [ ] Edge
