### PR TITLE
fix: focusing back-button would instantly go back

### DIFF
--- a/src/components/Layout/RegistrationLayout.tsx
+++ b/src/components/Layout/RegistrationLayout.tsx
@@ -61,7 +61,6 @@ const RegistrationLayout: React.FC<
         <Flex alignSelf="stretch" justifyContent="center" mb="small">
           <Flex
             onClick={() => window.history.back()}
-            onKeyUp={() => window.history.back()}
             role="button"
             tabIndex={0}
             zIndex={1}


### PR DESCRIPTION
**Ticket:** [#153](https://trello.com/c/RfA7brbN/153-tabbing-for-focus-goes-back-investigate-in-registrationlayout-back-button)
**Intent:**

When focusing the back button it would immediately go back.

**How to test (optional):**

Tab to navigate, when focus hits back button it should not go back unless pressed.

### All of the following commands should pass.

- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run cypress`

### Browser testing

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE11
- [ ] Edge
