### PR TITLE
fix: focusing custom elements

### DIFF
--- a/src/components/ButtonToInput.tsx
+++ b/src/components/ButtonToInput.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Tag from './Tag'
 import styled from '@emotion/styled'
 import { useToggle } from '@iteam/hooks'
+import { handleFocusKeyDown } from '../utils/helpers'
 
 interface ButtonToInputProps {
   buttonText: string
@@ -67,14 +68,23 @@ const ButtonToInput: React.FC<ButtonToInputProps> = ({
         borderRadius={8}
         ml={6}
         onClick={handleSelect}
+        onKeyDown={handleFocusKeyDown(handleSelect)}
         p="small"
         role="button"
+        tabIndex={0}
       >
         {addButtonText}
       </TagButton>
     </InputWrapper>
   ) : (
-    <Tag mb="medium" mt="small" onClick={setAddCompetenceActive} role="button">
+    <Tag
+      mb="medium"
+      mt="small"
+      onClick={setAddCompetenceActive}
+      onKeyDown={handleFocusKeyDown(setAddCompetenceActive)}
+      role="button"
+      tabIndex={0}
+    >
       {buttonText}
     </Tag>
   )

--- a/src/components/Layout/RegistrationLayout.tsx
+++ b/src/components/Layout/RegistrationLayout.tsx
@@ -5,6 +5,7 @@ import Button from '../Button'
 import { Paragraph } from '../Typography'
 import Grid from '../Grid'
 import Flex from '../Flex'
+import { handleFocusKeyDown } from '../../utils/helpers'
 import Icon from '../../assets/icons/navigation_arrow.svg'
 import { RouteComponentProps, navigate } from '@reach/router'
 
@@ -61,6 +62,7 @@ const RegistrationLayout: React.FC<
         <Flex alignSelf="stretch" justifyContent="center" mb="small">
           <Flex
             onClick={() => window.history.back()}
+            onKeyDown={handleFocusKeyDown(() => window.history.back())}
             role="button"
             tabIndex={0}
             zIndex={1}

--- a/src/components/TagList.tsx
+++ b/src/components/TagList.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Flex from './Flex'
 import Tag from './Tag'
+import { handleFocusKeyDown } from '../utils/helpers'
 
 interface TagItemProps {
   id: string
@@ -33,6 +34,9 @@ const TagList: React.FC<TagListProps<TagItemProps>> = ({
           key={item.id}
           m={6}
           onClick={() => onSelect(item)}
+          onKeyDown={handleFocusKeyDown(() => onSelect(item))}
+          role="button"
+          tabIndex={0}
           variant={itemIsActive(item.id) ? 'active' : 'default'}
         >
           {item.term}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -99,7 +99,7 @@ export const highlightMarked = (inputValue: string, term: string) => {
 }
 
 export const handleFocusKeyDown = (callback: () => void) => (
-  e: React.KeyboardEvent<HTMLSpanElement>
+  e: React.KeyboardEvent<HTMLElement>
 ) => {
   if (e.which === 13) {
     callback()

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -97,3 +97,11 @@ export const highlightMarked = (inputValue: string, term: string) => {
     __html: term.replace(reg, `<strong>${inputValue}</strong>`),
   }
 }
+
+export const handleFocusKeyDown = (callback: () => void) => (
+  e: React.KeyboardEvent<HTMLSpanElement>
+) => {
+  if (e.which === 13) {
+    callback()
+  }
+}

--- a/src/views/CreateProfile/AddTraits.tsx
+++ b/src/views/CreateProfile/AddTraits.tsx
@@ -21,7 +21,7 @@ import {
 import gql from 'graphql-tag'
 import { GET_ONTOLOGY_CONCEPTS } from './ChooseProfession'
 import { GET_TRAITS_CLIENT } from '../../graphql/resolvers/mutations/addTrait'
-import { highlightMarked } from '../../utils/helpers'
+import { highlightMarked, handleFocusKeyDown } from '../../utils/helpers'
 import TagList from '../../components/TagList'
 import RegistrationLayout from '../../components/Layout/RegistrationLayout'
 
@@ -47,6 +47,7 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
 
   const [traitQuery, setTraitQuery] = useState('')
   const [addTraitActive, setAddTraitActive] = useToggle(false)
+  const inputRef = React.useRef<HTMLInputElement>(null)
 
   const { data: ontologyRelated } = useQuery<{
     ontologyConcepts: Query['ontologyConcept'][]
@@ -100,7 +101,11 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
 
   useEffect(() => {
     setSuggestedTraits(suggestedTraits.filter(t => traits.indexOf(t) === -1))
-  }, [traits])
+
+    if (inputRef && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [traits, addTraitActive])
 
   return (
     <RegistrationLayout headerText="PERSON" nextPath="kontakt" step={5}>
@@ -143,6 +148,7 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
                   <Input
                     alignSelf="stretch"
                     border="none"
+                    ref={inputRef}
                     {...getInputProps({
                       name: 'trait',
                       placeholder: 'Lägg till en egenskap',
@@ -160,8 +166,13 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
                       handleChange(traitQuery)
                       setAddTraitActive()
                     }}
+                    onKeyDown={handleFocusKeyDown(() => {
+                      handleChange(traitQuery)
+                      setAddTraitActive()
+                    })}
                     p="small"
                     role="button"
+                    tabIndex={0}
                   >
                     OK
                   </TagButton>
@@ -212,6 +223,8 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
             mb="medium"
             mt="small"
             onClick={setAddTraitActive}
+            onKeyDown={handleFocusKeyDown(setAddTraitActive)}
+            tabIndex={0}
             role="button"
           >
             + Lägg till en ny egenskap

--- a/src/views/CreateProfile/AddTraits.tsx
+++ b/src/views/CreateProfile/AddTraits.tsx
@@ -224,8 +224,8 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
             mt="small"
             onClick={setAddTraitActive}
             onKeyDown={handleFocusKeyDown(setAddTraitActive)}
-            tabIndex={0}
             role="button"
+            tabIndex={0}
           >
             + Lägg till en ny egenskap
           </Tag>

--- a/src/views/CreateProfile/AddTraits.tsx
+++ b/src/views/CreateProfile/AddTraits.tsx
@@ -2,7 +2,7 @@ import { RouteComponentProps } from '@reach/router'
 import Flex from '../../components/Flex'
 import { v4 } from 'uuid'
 import { useMutation, useQuery } from 'react-apollo-hooks'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useDebounce, useToggle } from '@iteam/hooks'
 import Downshift from 'downshift'
 import { Global, css } from '@emotion/core'
@@ -47,7 +47,7 @@ const AddTraits: React.FC<RouteComponentProps> = ({ location }) => {
 
   const [traitQuery, setTraitQuery] = useState('')
   const [addTraitActive, setAddTraitActive] = useToggle(false)
-  const inputRef = React.useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const { data: ontologyRelated } = useQuery<{
     ontologyConcepts: Query['ontologyConcept'][]

--- a/src/views/CreateProfile/__tests__/__snapshots__/MatchSkills.spec.tsx.snap
+++ b/src/views/CreateProfile/__tests__/__snapshots__/MatchSkills.spec.tsx.snap
@@ -71,6 +71,7 @@ exports[`views/MatchSkills renders loading state 1`] = `
         cursor="pointer"
         opacity="1"
         role="button"
+        tabindex="0"
       >
         + Lägg till en kompetens
       </span>


### PR DESCRIPTION
**Ticket:** [#154](https://trello.com/c/r1yg4eoG/154-fokus-fungerar-inte-f%C3%B6r-taglist)
**Intent:**

Our custom elements did not support focus, TagList, BackButton etc.

**How to test (optional):**

Use tab and navigate through all steps

### All of the following commands should pass.

- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run cypress`

### Browser testing

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE11
- [ ] Edge
