### PR TITLE
chore: await docker images being pushed to hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
         - bash ./infrastructure/travis/install-openshift.sh
         - export PATH=$PATH:/tmp/openshift
         - npm i -D @semantic-release/commit-analyzer @semantic-release/release-notes-generator
-          @semantic-release/github @semantic-release/exec semantic-release-docker
+          @semantic-release/github @semantic-release/exec lundeeell/semantic-release-docker
       script:
         - docker build . -t jobtechswe/myskills-web
           --build-arg REACT_APP_GRAPHQL_URI=$REACT_APP_GRAPHQL_URI


### PR DESCRIPTION
docker images is pushed async, therefore, deploy will be made with old packages. Forked semantic-release-docker and added await to test out