### PR TITLE
fix: show 0 years if user has no experience

### DIFF
--- a/src/views/Profile/Home.tsx
+++ b/src/views/Profile/Home.tsx
@@ -134,7 +134,11 @@ const Home: React.FC<RouteComponentProps> = ({
               <H2 mb="small">Erfarenhet</H2>
               {data.occupation && (
                 <Paragraph mb="small" mt="none">
-                  {`${data.occupation.experience.years} års erfarenhet som 
+                  {`${
+                    data.occupation.experience
+                      ? data.occupation.experience.years
+                      : 0
+                  } års erfarenhet som
                   ${data.occupation.term}.`}
                 </Paragraph>
               )}

--- a/src/views/Profile/__tests__/__snapshots__/Home.spec.tsx.snap
+++ b/src/views/Profile/__tests__/__snapshots__/Home.spec.tsx.snap
@@ -265,7 +265,7 @@ exports[`views/profile/Home should render with profile data 1`] = `
           font-family="default"
           font-size="small"
         >
-          4 års erfarenhet som 
+          4 års erfarenhet som
                   Systemutvecklare.
         </p>
         <p


### PR DESCRIPTION
Before: tried to access the year-value of null (experiences)

**Ticket:** [#171](https://trello.com/c/pW7XtyME/171-frontend-krashar-om-experience-inte-ifyllt)
**Intent:**
**How to test (optional):**

### All of the following commands should pass.

- [ ] `npm test`
- [ ] `npm run lint`
- [ ] `npm run cypress`

### Browser testing

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE11
- [ ] Edge
