### PR TITLE
feat: add 404 page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Loader from 'components/Loader'
 
 const Login = React.lazy(() => import(`views/Login/Login`))
 const Start = React.lazy(() => import(`views/Start/Start`))
+const NotFound = React.lazy(() => import(`views/NotFound`))
 const Profile = React.lazy(() => import('views/Profile/Profile'))
 
 const RegistrationCompleted = React.lazy(() =>
@@ -69,6 +70,7 @@ function App() {
             <RestrictedRoute component={Home} path="/" />
             <RestrictedRoute component={Timeline} path="/tidslinje" />
           </Profile>
+          <NotFound default />
         </Router>
       </React.Suspense>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,11 +64,13 @@ function App() {
             <WorkExperiences path="/erfarenheter/tidigare-erfarenheter" />
             <AddContactInformation path="/kontakt" />
             <SaveCV path="/spara-cv" />
+            <NotFound default />
           </CreateProfile>
 
           <Profile path="/profil">
             <RestrictedRoute component={Home} path="/" />
             <RestrictedRoute component={Timeline} path="/tidslinje" />
+            <NotFound default />
           </Profile>
           <NotFound default />
         </Router>

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -1,0 +1,32 @@
+import { RouteComponentProps } from '@reach/router'
+import React from 'react'
+import styled from '@emotion/styled'
+import Flex from '../components/Flex'
+import { InternalLink } from '../components/Link'
+import Button from '../components/Button'
+import { Paragraph } from '../components/Typography'
+
+const Block = styled.span`
+  align-items: center;
+  background: ${({ theme }) => `radial-gradient(
+    647.69px at 6.66% 96.53%,
+    ${theme.colors.yourPink} 0%,
+    ${theme.colors.seashellPeach} 100%
+  )`};
+  display: grid;
+  justify-content: center;
+  min-height: 677px;
+  font-weight: bold;
+`
+
+const NotFound: React.FC<RouteComponentProps> = () => {
+  return (
+    <Block>
+      <Paragraph>The page could not be found :( </Paragraph>
+      <InternalLink to={'/'}>
+        <Button>{'Go to start'}</Button>
+      </InternalLink>
+    </Block>
+  )
+}
+export default NotFound

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -5,23 +5,20 @@ import Flex from '../components/Flex'
 import { InternalLink } from '../components/Link'
 import Button from '../components/Button'
 import { Paragraph } from '../components/Typography'
+import Grid from 'components/Grid'
 
-const Block = styled.span`
-  align-items: center;
+const Block = styled(Grid)`
   background: ${({ theme }) => `radial-gradient(
     647.69px at 6.66% 96.53%,
     ${theme.colors.yourPink} 0%,
     ${theme.colors.seashellPeach} 100%
   )`};
-  display: grid;
-  justify-content: center;
-  min-height: 677px;
   font-weight: bold;
 `
 
 const NotFound: React.FC<RouteComponentProps> = () => {
   return (
-    <Block>
+    <Block alignItems="center" height="100vh" justifyItems="center">
       <Paragraph>The page could not be found :( </Paragraph>
       <InternalLink to={'/'}>
         <Button>{'Go to start'}</Button>

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -1,7 +1,6 @@
 import { RouteComponentProps } from '@reach/router'
 import React from 'react'
 import styled from '@emotion/styled'
-import Flex from '../components/Flex'
 import { InternalLink } from '../components/Link'
 import Button from '../components/Button'
 import { Paragraph } from '../components/Typography'


### PR DESCRIPTION
**Ticket:** [#169](https://trello.com/c/S1YcT5py/169-redirecta-alla-routes-som-inte-finns-till-en-404-sida)
**Intent:**
Instead of showing the user a blank page, gives them back a 404 page.
**How to test (optional):**

### All of the following commands should pass.

- [ ] `npm test`
- [ ] `npm run lint`
- [ ] `npm run cypress`

### Browser testing

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE11
- [ ] Edge
