### PR TITLE
fix: startpage not showing all content on mobile

### DIFF
--- a/src/theme/globalStyle.ts
+++ b/src/theme/globalStyle.ts
@@ -156,6 +156,7 @@ export const globalStyle = css`
     box-sizing: border-box;
   }
   #root {
+    /* Explanation: https://css-tricks.com/the-trick-to-viewport-units-on-mobile/ */
     height: calc(var(--vh, 1vh) * 100);
   }
 

--- a/src/views/Start/Start.tsx
+++ b/src/views/Start/Start.tsx
@@ -23,7 +23,8 @@ const StartBlock = styled.div`
   display: flex;
   justify-content: center;
   padding: 25px;
-  height: 100vh;
+  /* Explanation: https://css-tricks.com/the-trick-to-viewport-units-on-mobile/ */
+  height: calc(var(--vh, 1vh) * 100);
 `
 
 const InfoBlock = styled.div`

--- a/src/views/Start/__tests__/__snapshots__/Start.spec.tsx.snap
+++ b/src/views/Start/__tests__/__snapshots__/Start.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`views/Start renders Start 1`] = `
 <div>
   <div
-    class="css-dv50ng"
+    class="css-xvdcgw"
   >
     <div
       class="css-1fq4wiq"


### PR DESCRIPTION
**Ticket:** [#187](https://trello.com/c/YHl2yLMF/187-startsidan-visar-inte-all-content-p%C3%A5-riktig-mobil)
**Intent:**

Some content fell out on a real mobile device on the startpage

**How to test (optional):**

Open the start-page on a mobile-device, the following content should be seen:

![image](https://user-images.githubusercontent.com/17602389/58415699-96294600-807f-11e9-91df-6a3a4e3e05a6.png)


### All of the following commands should pass.

- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run cypress`

### Browser testing

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE11
- [ ] Edge
