### PR TITLE
fix: scrolling on route-transition

### DIFF
--- a/src/theme/globalStyle.ts
+++ b/src/theme/globalStyle.ts
@@ -172,6 +172,13 @@ export const globalStyle = css`
 `
 
 export const routeTransitionStyles = css`
+  [class^='fadeTranslate-'] {
+    display: none;
+  }
+  [class^='fadeTranslate-']:first-of-type {
+    display: block;
+  }
+
   .fadeTranslate-enter {
     opacity: 0;
   }


### PR DESCRIPTION
**Ticket:** [#191](https://trello.com/c/2RCEjLFu/191-n%C3%A4r-man-navigerar-till-n%C3%A4sta-sk%C3%A4rm-s%C3%A5-renderas-en-extra-komponent)
**Intent:**

When transitioning from one route to another the Transition library would render two components which lead to 200vh for a moment. This should fix that.

**How to test (optional):**

Navigate to the next screen, try to scroll down, you should not be able to scroll further than the first continue-button

### All of the following commands should pass.

- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run cypress`

### Browser testing

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE11
- [ ] Edge
